### PR TITLE
Added merge sort (clones way too much)

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -63,6 +63,8 @@ fn main() {
             println!("{} {} {} {}", "quick", n, took.0, took.1);
             let took = bench(StdSorter, &values, &counter);
             println!("{} {} {} {}", "std", n, took.0, took.1);
+            let took = clone_bench(MergeSort, &values, &counter);
+            println!("{} {} {} {}", "merge", n, took.0, took.1);
         }
     }
 }
@@ -76,6 +78,24 @@ fn bench<T: Ord + Clone, S: Sorter>(
     counter.set(0);
     let time = std::time::Instant::now();
     sorter.sort(&mut values);
+    let took = time.elapsed();
+    let count = counter.get();
+    // assert!(values.is_sorted());
+    for i in 1..values.len() {
+        assert!(values[i] >= values[i - 1]);
+    }
+    (count, took.as_secs_f64())
+}
+
+fn clone_bench<T: Ord + Clone, S: CloneSorter>(
+    sorter: S,
+    values: &[SortEvaluator<T>],
+    counter: &Cell<usize>,
+) -> (usize, f64) {
+    let mut values: Vec<_> = values.to_vec();
+    counter.set(0);
+    let time = std::time::Instant::now();
+    sorter.clone_sort(&mut values);
     let took = time.elapsed();
     let count = counter.get();
     // assert!(values.is_sorted());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,21 @@ pub trait Sorter {
     where
         T: Ord;
 }
+pub trait CloneSorter {
+    fn clone_sort<T>(&self, slice: &mut [T])
+    where
+        T: Ord+Clone;
+}
 
 mod bubblesort;
 mod insertionsort;
+mod mergesort;
 mod quicksort;
 mod selectionsort;
 
 pub use bubblesort::BubbleSort;
 pub use insertionsort::InsertionSort;
+pub use mergesort::MergeSort;
 pub use quicksort::QuickSort;
 pub use selectionsort::SelectionSort;
 

--- a/src/mergesort.rs
+++ b/src/mergesort.rs
@@ -1,0 +1,53 @@
+use super::CloneSorter;
+
+pub struct MergeSort;
+
+impl CloneSorter for MergeSort {
+    fn clone_sort<T>(&self, slice: &mut [T])
+    where
+        T: Ord+Clone,
+    {
+        //FIXME: not require T: Clone
+        //FIXME: not require n log(n) memory
+        //divide the list in half
+        if slice.len() <= 1 {
+            //Slices of 0 or 1 elements are already sorted
+            return;
+        }
+        let (left, right) = slice.split_at(slice.len()/2);
+        let (mut left, mut right) = (left.to_vec(), right.to_vec());
+        self.clone_sort(&mut left);
+        self.clone_sort(&mut right);
+        //merge into original list
+        let (mut i_left, mut i_right) = (0,0);
+        for i in 0..slice.len(){
+            if i_left >= left.len(){
+                //copy the rest of right to the slice
+                slice[i..].swap_with_slice(&mut right[i_right..]);
+                return;
+            }
+            if i_right >= right.len(){
+                //copy the rest of left to the slice
+                slice[i..].swap_with_slice(&mut left[i_left..]);
+                return;
+            }
+            slice[i] = if left[i_left] < right[i_right]{
+                let val = left[i_left].clone();
+                i_left += 1;
+                val
+            } else {
+                let val = right[i_right].clone();
+                i_right += 1;
+                val
+            };
+        }
+    }
+}
+
+#[test]
+fn it_works() {
+    let mut things = vec![4, 2, 5, 3, 1];
+    MergeSort.clone_sort(&mut things);
+    assert_eq!(things, &[1, 2, 3, 4, 5]);
+}
+


### PR DESCRIPTION
This works, but does too many allocations. Also, merge sort needs to keep a copy of the array, so I added a `CloneSorter` trait that adds the requirement that `T` is `Clone`. It might make more sense to change `Sorter` to `Sorter<T>` and let the sort implementations choose what traits to require (radix sort for example isn't a comparison sort, but should work for anything that can be converted into a byte array that compares the same way as the underlying type (integers, strings, composite structs, etc.)), but that's out of the scope of this pull request. An alternative is to require `T: Ord+Clone` on sorter directly.