### PR TITLE
Changed Sorter trait to be generic

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -65,9 +65,9 @@ fn main() {
     }
 }
 
-fn bench<T: Ord + Clone, S: Sorter>(
+fn bench<T: Ord + Clone, S: Sorter<T>>(
     sorter: S,
-    values: &[SortEvaluator<T>],
+    values: &[T],
     counter: &Cell<usize>,
 ) -> (usize, f64) {
     let mut values: Vec<_> = values.to_vec();

--- a/src/bubblesort.rs
+++ b/src/bubblesort.rs
@@ -2,8 +2,8 @@ use super::Sorter;
 
 pub struct BubbleSort;
 
-impl Sorter for BubbleSort {
-    fn sort<T>(&self, slice: &mut [T])
+impl<T> Sorter<T> for BubbleSort {
+    fn sort(&self, slice: &mut [T])
     where
         T: Ord,
     {

--- a/src/insertionsort.rs
+++ b/src/insertionsort.rs
@@ -4,8 +4,8 @@ pub struct InsertionSort {
     pub smart: bool,
 }
 
-impl Sorter for InsertionSort {
-    fn sort<T>(&self, slice: &mut [T])
+impl<T> Sorter<T> for InsertionSort {
+    fn sort(&self, slice: &mut [T])
     where
         T: Ord,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-pub trait Sorter {
-    fn sort<T>(&self, slice: &mut [T])
+pub trait Sorter<T>{
+    fn sort(&self, slice: &mut [T])
     where
         T: Ord;
 }
@@ -15,8 +15,8 @@ pub use quicksort::QuickSort;
 pub use selectionsort::SelectionSort;
 
 pub struct StdSorter;
-impl Sorter for StdSorter {
-    fn sort<T>(&self, slice: &mut [T])
+impl<T> Sorter<T> for StdSorter {
+    fn sort(&self, slice: &mut [T])
     where
         T: Ord,
     {

--- a/src/quicksort.rs
+++ b/src/quicksort.rs
@@ -54,8 +54,8 @@ fn quicksort<T: Ord>(slice: &mut [T]) {
     quicksort(&mut right[1..]);
 }
 
-impl Sorter for QuickSort {
-    fn sort<T>(&self, slice: &mut [T])
+impl<T> Sorter<T> for QuickSort {
+    fn sort(&self, slice: &mut [T])
     where
         T: Ord,
     {

--- a/src/selectionsort.rs
+++ b/src/selectionsort.rs
@@ -2,8 +2,8 @@ use super::Sorter;
 
 pub struct SelectionSort;
 
-impl Sorter for SelectionSort {
-    fn sort<T>(&self, slice: &mut [T])
+impl<T> Sorter<T> for SelectionSort {
+    fn sort(&self, slice: &mut [T])
     where
         T: Ord,
     {


### PR DESCRIPTION
This will make the trait object safe, and also allow implementations of
sorting algorithms that do not work for all `Ord` types.