### PR TITLE
Modified bench.rs for geom_smooth to work and added sort_unstable from rust stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Implementation of various [sorting algorithms] in Rust from [this live
 stream].
 
+Modify `MAX_ELEMENT` and `MIN_ELEMENT` in bench function to control the no. of elements (`n`) and benchmark different scenarios.
+
 To benchmark and plot (you'll need [R] and [ggplot2]):
 
 ```console
@@ -9,12 +11,14 @@ $ R
 t <- read.table('values.dat', header=TRUE)
 library(ggplot2)
 # to plot # comparisons
-ggplot(t, aes(n, comparisons, colour = algorithm)) + geom_point() + scale_y_log10()
+ggplot(t, aes(n, comparisons, colour = algorithm, linetype = algorithm)) + geom_point(size = 0.4, show.legend = FALSE) + geom_smooth(method = "gam") + scale_y_log10()
 # to plot runtime
-ggplot(t, aes(n, time, colour = algorithm)) + geom_point() + scale_y_log10()
+ggplot(t, aes(n, time, colour = algorithm, linetype = algorithm)) + geom_point(size = 0.4, show.legend = FALSE) + geom_smooth(method = "gam") + scale_y_log10()
 ```
+
+In case of errors with `geom_smooth()`, remove `method = "gam"`. This occurs if there are very few data points.
 
 [sorting algorithms]: https://en.wikipedia.org/wiki/Sorting_algorithm
 [this live stream]: https://www.youtube.com/watch?v=h4RkCyJyXmM
-[R]: https://www.r-project.org/
+[r]: https://www.r-project.org/
 [ggplot2]: https://ggplot2.tidyverse.org/

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -2,8 +2,12 @@ use orst::*;
 
 use rand::prelude::*;
 use std::cell::Cell;
-use std::cmp::Ordering;
+use std::cmp::{max, Ordering};
 use std::rc::Rc;
+
+//only the first digit of MIN_ELEMENT and MAX_ELEMENT is considered
+const MIN_ELEMENT: usize = 0;
+const MAX_ELEMENT: u32 = 6000;
 
 #[derive(Clone)]
 struct SortEvaluator<T> {
@@ -35,9 +39,26 @@ impl<T: Ord> Ord for SortEvaluator<T> {
 fn main() {
     let mut rand = rand::thread_rng();
     let counter = Rc::new(Cell::new(0));
+    assert!(
+        MAX_ELEMENT >= (MIN_ELEMENT + 10_usize.pow((MIN_ELEMENT as f64).log10() as u32)) as u32,
+        "MAX_ELEMENT should be greater than (MIN_ELEMENT + 10^log10(MIN_ELEMENT))"
+    );
+    let digits_max: u32 = (MAX_ELEMENT as f64).log10() as u32;
+    let digits_min: u32 = max(0, (MIN_ELEMENT as f64).log10() as u32);
+    let n_max: usize = (digits_max * 9 + MAX_ELEMENT / (10_u32.pow(digits_max))) as usize;
+    let n_min: usize = (digits_min * 9 + MIN_ELEMENT as u32 / (10_u32.pow(digits_min))) as usize;
+    let index = n_max - n_min + 1;
+    let mut items = Vec::with_capacity(index);
+    let rounded_min_element = (n_min - digits_min as usize * 9) * (10_u32.pow(digits_min)) as usize;
+    items.push(rounded_min_element);
+    for _ in 1..index {
+        let items_clone = items.clone();
+        let la = items_clone.last().unwrap();
+        items.push(la + 10_i32.pow((*la as f64).log10() as u32) as usize);
+    }
 
     println!("algorithm n comparisons time");
-    for &n in &[0, 1, 10, 100, 1000, 10000] {
+    for &n in &items {
         let mut values = Vec::with_capacity(n);
         for _ in 0..n {
             values.push(SortEvaluator {
@@ -59,10 +80,10 @@ fn main() {
             println!("{} {} {} {}", "selection", n, took.0, took.1);
             let took = bench(QuickSort, &values, &counter);
             println!("{} {} {} {}", "quick", n, took.0, took.1);
-            let took = bench(QuickSort, &values, &counter);
-            println!("{} {} {} {}", "quick", n, took.0, took.1);
             let took = bench(StdSorter, &values, &counter);
-            println!("{} {} {} {}", "std", n, took.0, took.1);
+            println!("{} {} {} {}", "stdstable", n, took.0, took.1);
+            let took = bench(StdUnstableSorter, &values, &counter);
+            println!("{} {} {} {}", "stdunstable", n, took.0, took.1);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,16 @@ impl Sorter for StdSorter {
     }
 }
 
+pub struct StdUnstableSorter;
+impl Sorter for StdUnstableSorter {
+    fn sort<T>(&self, slice: &mut [T])
+    where
+        T: Ord,
+    {
+        slice.sort_unstable();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -32,6 +42,13 @@ mod tests {
     fn std_works() {
         let mut things = vec![4, 2, 3, 1];
         StdSorter.sort(&mut things);
+        assert_eq!(things, &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn stdunstable_works() {
+        let mut things = vec![4, 2, 3, 1];
+        StdUnstableSorter.sort(&mut things);
         assert_eq!(things, &[1, 2, 3, 4]);
     }
 }


### PR DESCRIPTION
Now you can do benchmark by controlling the minimum and the maximum number of elements, and the geom_smooth will always work due to the availability of data points.

Also, there is a faster implementation of rust sort which is known in `stdlib` as `sort_unstable`. Added the same for comparison purposes.